### PR TITLE
Auto-generate .env backend config file during dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,11 @@ registration of a test user, however if you encounter errors you may need to cre
 npm run prepare-environment
 ```
 - This will install the dependencies needed by the frontend and the backend.
-3. Start the application
+3. The previous step will also create a ".env" configuration file in the root of the backend directory. This file contains environmental variables that are used by the backend server, and as each developer will have different values for these variables, it is not included in the repository. The .env file holds fields by default to specify the port on which the backend server will run, the MongoDB connection string, and the secret key used to sign JWTs and cookies. You will need to fill in these fields with the appropriate values for your local environment.
+4. Start the application
 * From the root project directory run:
 ```bash
 npm start
 ```
 - This will start the frontend development server. A browser window should open automatically and navigate to http://localhost:3000. If it does not, you can manually navigate to that URL.
-- Additionally, the backend server will start on port 5000. You can test that it is running by navigating to http://localhost:5000/api/test. You should see a message that says "API is running...".
-
-# Configuration for backend
-* TODO Create template .env or give instructions on how to create one
+- Additionally, the backend server will start on port 5000 by default. You can test that it is running by navigating to http://localhost:5000/api/test. You should see a message that says "API is running...".

--- a/backend/createEnv.js
+++ b/backend/createEnv.js
@@ -1,4 +1,4 @@
-// Using NodeJS to craate .env file in this directory
+// This script creates a .env file with a template for the environment variables
 // This'll be run automatically in the dependencies installation process
 // If you want to run it manually, run the following command in the terminal
 // node createEnv.js
@@ -6,8 +6,7 @@
 const fs = require('fs');
 
 const template =
-    `
-# Specify the port on which the Express server will listen
+`# Specify the port on which the Express server will listen
 PORT=5000
 # Create a random string as a secret key for the JSON Web Token
 JWT_SECRET=

--- a/backend/createEnv.js
+++ b/backend/createEnv.js
@@ -1,0 +1,30 @@
+// Using NodeJS to craate .env file in this directory
+// This'll be run automatically in the dependencies installation process
+// If you want to run it manually, run the following command in the terminal
+// node createEnv.js
+
+const fs = require('fs');
+
+const template =
+    `
+# Specify the port on which the Express server will listen
+PORT=5000
+# Create a random string as a secret key for the JSON Web Token
+JWT_SECRET=
+# Create a random string as a secret key to sign cookies
+COOKIE_SECRET=
+# Specify the URL of the MongoDB database, the Community DB defaults to the following
+MONGODB_URI=mongodb://localhost:27017/intrepid
+# Specify the timeout for the MongoDB connection
+MONGODB_TIMEOUT=1500
+`;
+
+if (fs.existsSync('.env')) {
+    console.log('Environment variables config file already exists');
+    return;
+}
+
+fs.writeFile('.env', template, (err) => {
+    if (err) throw err;
+    console.log('Environment variables config file created successfully');
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "start": "nodemon server.js",
+    "create-env": "node createEnv.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -33,9 +33,8 @@ const authRouter = require("./routes/authRoutes");
 // Activate our API endpoints
 app.use("/api/auth", authRouter);
 
-
 app.get("/test", (req, res) => {
-    res.send("Hello World");
+    res.send("API is running...");
 });
 
 // Serve static assets if in production

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "concurrently \"npm run start-frontend\" \"npm run start-backend\"",
-    "prepare-environment": "npm install && npm install --prefix frontend && npm install --prefix backend",
+    "prepare-environment": "npm install && npm install --prefix frontend && npm install --prefix backend && npm run --prefix backend create-env",
     "start-frontend": "npm start --prefix frontend",
     "start-backend": "npm start --prefix backend",
     "test-frontend": "npm test --prefix frontend"


### PR DESCRIPTION
I've created a script that'll generate a .env environmental variables config for use by the Node.js backend on the fly during run of `npm run prepare-environment`
This file holds environment variables for the backend server such as the port it'll run on, the MongoDB connection string, cookie & JWT secret signing keys, and more. You'll be able to specify those on your own environment once the file is generated.
Instructions for doing this have been added to the root README.