### PR TITLE
CORS Fix - Specify allowed origins

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -21,8 +21,11 @@ app.use(cookieParser(process.env.COOKIE_SECRET));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
-// Enable CORS, and allow credentials (cookies, tokens, etc.) to be passed; ideally limit it to only the client's origin
-app.use(cors({ credentials: true }));
+// Enable CORS bypass for the frontend, and allow credentials (cookies, etc.) to be passed
+app.use(cors({
+    origin: [process.env.CLIENT_ORIGIN || "http://localhost:3000"],
+    credentials: true
+}));
 
 // Disable the X-Powered-By header to prevent information leakage about the server
 app.disable("x-powered-by");

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -26,7 +26,8 @@ sagaMiddleware.run(intrepidSaga)
 // Ensure Axios sends the HttpOnly JWT cookies with every request
 if (process.env.NODE_ENV === 'development') {
   // Set this to the port your backend server is running on
-  axios.defaults.baseURL = `http://127.0.0.1:5000/`;
+  // TODO: Make this dynamic if we're going to deploy to Heroku (process.env.REACT_APP_BACKEND_API_URL)
+  axios.defaults.baseURL = `http://127.0.0.1:5000`;
   // So rather than typing http://localhost:5000/api/auth/login,
   // we can just type /api/users/login in axios requests
 }


### PR DESCRIPTION
We have to specify the allowed origins from which the Express server will allow requests containing "credentials" - in our case the HttpOnly JWT cookie, otherwise the requests will get blocked due to CORS.

We'll have to adjust it if we end up deploying to Heroku or somewhere else to incorporate that origin URL.